### PR TITLE
Add message type property to analysis message

### DIFF
--- a/ChatAnalyzer.Domain/Entities/AnalysisMessage.cs
+++ b/ChatAnalyzer.Domain/Entities/AnalysisMessage.cs
@@ -1,13 +1,17 @@
-﻿namespace ChatAnalyzer.Domain.Entities;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ChatAnalyzer.Domain.Entities;
 
 public class AnalysisMessage
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    [Key] public Guid Id { get; set; } = Guid.NewGuid();
 
     public string Content { get; set; } = string.Empty;
 
     public Guid AnalysisId { get; set; }
     public Analysis Analysis { get; set; } = null!;
+
+    public MessageType MessageType { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/ChatAnalyzer.Domain/Entities/MessageType.cs
+++ b/ChatAnalyzer.Domain/Entities/MessageType.cs
@@ -1,0 +1,7 @@
+﻿namespace ChatAnalyzer.Domain.Entities;
+
+public enum MessageType
+{
+    Received,
+    Sent
+}

--- a/ChatAnalyzer.Infrastructure/Migrations/20250416114116_AddMessageTypeToAnalysisMessage.Designer.cs
+++ b/ChatAnalyzer.Infrastructure/Migrations/20250416114116_AddMessageTypeToAnalysisMessage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ChatAnalyzer.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ChatAnalyzer.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416114116_AddMessageTypeToAnalysisMessage")]
+    partial class AddMessageTypeToAnalysisMessage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ChatAnalyzer.Infrastructure/Migrations/20250416114116_AddMessageTypeToAnalysisMessage.cs
+++ b/ChatAnalyzer.Infrastructure/Migrations/20250416114116_AddMessageTypeToAnalysisMessage.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ChatAnalyzer.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMessageTypeToAnalysisMessage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MessageType",
+                table: "AnalysisMessages",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MessageType",
+                table: "AnalysisMessages");
+        }
+    }
+}

--- a/ChatAnalyzer.Presentation/Controllers/AnalysesController.cs
+++ b/ChatAnalyzer.Presentation/Controllers/AnalysesController.cs
@@ -50,6 +50,7 @@ public class AnalysesController(IAnalysisService analysisService) : ControllerBa
             {
                 Id = m.Id,
                 Content = m.Content,
+                MessageType = m.MessageType,
                 CreatedAt = m.CreatedAt,
                 UpdatedAt = m.UpdatedAt
             }),
@@ -101,6 +102,7 @@ public class AnalysesController(IAnalysisService analysisService) : ControllerBa
                 {
                     Id = m.Id,
                     Content = m.Content,
+                    MessageType = m.MessageType,
                     CreatedAt = m.CreatedAt,
                     UpdatedAt = m.UpdatedAt
                 }),
@@ -135,6 +137,7 @@ public class AnalysesController(IAnalysisService analysisService) : ControllerBa
             {
                 Id = m.Id,
                 Content = m.Content,
+                MessageType = m.MessageType,
                 CreatedAt = m.CreatedAt,
                 UpdatedAt = m.UpdatedAt
             }),

--- a/ChatAnalyzer.Presentation/Responses/AnalysisMessageDto.cs
+++ b/ChatAnalyzer.Presentation/Responses/AnalysisMessageDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using ChatAnalyzer.Domain.Entities;
 
 namespace ChatAnalyzer.Presentation.Responses;
 
@@ -6,6 +7,7 @@ public class AnalysisMessageDto
 {
     [JsonPropertyName("id")] public Guid Id { get; set; }
     [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("type")] public MessageType MessageType { get; set; }
     [JsonPropertyName("created_at")] public DateTime CreatedAt { get; set; }
     [JsonPropertyName("updated_at")] public DateTime UpdatedAt { get; set; }
 }


### PR DESCRIPTION
Add a new `MessageType` property to `AnalysisMessage` entities and ensuring that this new property is properly handled across various layers of the application.

### Domain Model Updates:
* **`ChatAnalyzer.Domain/Entities/AnalysisMessage.cs`**: Added a new `MessageType` property to the `AnalysisMessage` class and marked the `Id` property with a `[Key]` attribute.
* **`ChatAnalyzer.Domain/Entities/MessageType.cs`**: Introduced a new `MessageType` enum with values `Received` and `Sent`.

### Service Layer Updates:
* **`ChatAnalyzer.Application/Services/AnalysisService.cs`**: Updated methods `CreateAsync` and `AskAsync` to set the `MessageType` property for `AnalysisMessage` instances accordingly.

### Database Migrations:
* Added a new migration to include the `MessageType` column in the `AnalysisMessages` table.

### Presentation Layer Updates:
* **`ChatAnalyzer.Presentation/Controllers/AnalysesController.cs`**: Updated various controller actions to include the `MessageType` property in the response DTOs.
* **`ChatAnalyzer.Presentation/Responses/AnalysisMessageDto.cs`**: Added the `MessageType` property to the `AnalysisMessageDto` class.