### PR TITLE
Add integration tests for AnalysesController endpoints

### DIFF
--- a/backend/ChatAnalyzer.IntegrationTests/Auth/TestAuthHandler.cs
+++ b/backend/ChatAnalyzer.IntegrationTests/Auth/TestAuthHandler.cs
@@ -1,0 +1,30 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ChatAnalyzer.IntegrationTests.Auth;
+
+public class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    ISystemClock timeProvider)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder, timeProvider)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "11111111-1111-1111-1111-111111111111"),
+            new Claim(ClaimTypes.Name, "testuser@example.com")
+        };
+
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "Test");
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/backend/ChatAnalyzer.IntegrationTests/ChatAnalyzer.IntegrationTests.csproj
+++ b/backend/ChatAnalyzer.IntegrationTests/ChatAnalyzer.IntegrationTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="FluentAssertions" Version="8.2.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ChatAnalyzer.Presentation\ChatAnalyzer.Presentation.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/backend/ChatAnalyzer.IntegrationTests/ChatAnalyzerWebApplicationFactory.cs
+++ b/backend/ChatAnalyzer.IntegrationTests/ChatAnalyzerWebApplicationFactory.cs
@@ -1,0 +1,45 @@
+﻿using ChatAnalyzer.Domain.Entities;
+using ChatAnalyzer.Infrastructure.Persistence;
+using ChatAnalyzer.IntegrationTests.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ChatAnalyzer.IntegrationTests;
+
+public class ChatAnalyzerWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureServices(services =>
+        {
+            services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+
+            services.PostConfigureAll<AuthenticationOptions>(options =>
+            {
+                options.DefaultAuthenticateScheme = "Test";
+                options.DefaultChallengeScheme = "Test";
+            });
+
+            var sp = services.BuildServiceProvider();
+
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var testUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+            if (db.Users.Any(u => u.Id == testUserId)) return;
+
+            db.Users.Add(new ApplicationUser
+            {
+                Id = testUserId,
+                Email = "testuser@example.com"
+            });
+            db.SaveChanges();
+        });
+    }
+}

--- a/backend/ChatAnalyzer.IntegrationTests/Controllers/AnalysesControllerTests.cs
+++ b/backend/ChatAnalyzer.IntegrationTests/Controllers/AnalysesControllerTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
+using ChatAnalyzer.Presentation.Requests;
 using FluentAssertions;
+using static System.Net.Http.Headers.MediaTypeHeaderValue;
 
 namespace ChatAnalyzer.IntegrationTests.Controllers;
 
@@ -13,7 +15,6 @@ public class AnalysesControllerTests(ChatAnalyzerWebApplicationFactory factory)
     [Fact]
     public async Task CreateAnalysis_ValidChat_ReturnsSuccess()
     {
-        // Arrange
         const string json = """
                             {
                               "name": "Test Chat",
@@ -38,17 +39,70 @@ public class AnalysesControllerTests(ChatAnalyzerWebApplicationFactory factory)
                               ]
                             }
                             """;
+
         var content = new MultipartFormDataContent();
         var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(json));
-        fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+        fileContent.Headers.ContentType = Parse("application/json");
         content.Add(fileContent, "file", "chat.json");
 
-        // Act
         var response = await _client.PostAsync("/api/analyses", content);
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().Contain("Test Chat");
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkAndEmptyListInitially()
+    {
+        var response = await _client.GetAsync("/api/analyses");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("[");
+    }
+
+    [Fact]
+    public async Task GetChat_NonExistentId_ReturnsNotFound()
+    {
+        var fakeId = Guid.NewGuid();
+
+        var response = await _client.GetAsync($"/api/analyses/{fakeId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task AddMessage_ToNonExistentAnalysis_ReturnsNotFound()
+    {
+        var fakeId = Guid.NewGuid();
+
+        var request = new AddMessageDto
+        {
+            Message = "What is the summary?"
+        };
+
+        var response = await _client.PostAsJsonAsync($"/api/analyses/{fakeId}/messages", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateAnalysis_InvalidJson_ReturnsBadRequest()
+    {
+        const string badJson = """
+                               { "invalid": true
+                               """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(badJson));
+        fileContent.Headers.ContentType = Parse("application/json");
+        content.Add(fileContent, "file", "bad_chat.json");
+
+        var response = await _client.PostAsync("/api/analyses", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Contain("An error occurred while processing the file");
     }
 }

--- a/backend/ChatAnalyzer.IntegrationTests/Controllers/AnalysesControllerTests.cs
+++ b/backend/ChatAnalyzer.IntegrationTests/Controllers/AnalysesControllerTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using FluentAssertions;
+
+namespace ChatAnalyzer.IntegrationTests.Controllers;
+
+public class AnalysesControllerTests(ChatAnalyzerWebApplicationFactory factory)
+    : IClassFixture<ChatAnalyzerWebApplicationFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task CreateAnalysis_ValidChat_ReturnsSuccess()
+    {
+        // Arrange
+        const string json = """
+                            {
+                              "name": "Test Chat",
+                              "type": "personal_chat",
+                              "id": 0,
+                              "messages": [
+                                {
+                                  "id": 0,
+                                  "type": "message",
+                                  "date": "2025-05-07T20:18:04",
+                                  "date_unixtime": "1746638284",
+                                  "from": "0",
+                                  "from_id": "0",
+                                  "text": "0",
+                                  "text_entities": [
+                                    {
+                                      "type": "plain",
+                                      "text": "0"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                            """;
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(json));
+        fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+        content.Add(fileContent, "file", "chat.json");
+
+        // Act
+        var response = await _client.PostAsync("/api/analyses", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        responseBody.Should().Contain("Test Chat");
+    }
+}

--- a/backend/ChatAnalyzer.Presentation/Program.cs
+++ b/backend/ChatAnalyzer.Presentation/Program.cs
@@ -45,3 +45,6 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+// This class is needed for integration tests to work properly
+public partial class Program;

--- a/backend/ChatAnalyzer.sln
+++ b/backend/ChatAnalyzer.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatAnalyzer.Domain", "Chat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatAnalyzer.Infrastructure", "ChatAnalyzer.Infrastructure\ChatAnalyzer.Infrastructure.csproj", "{351BFBE8-E7BC-4EB7-A9DD-E114DA255B5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatAnalyzer.IntegrationTests", "ChatAnalyzer.IntegrationTests\ChatAnalyzer.IntegrationTests.csproj", "{D4C6B10A-6C62-4A31-A681-4DDB78320D9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{351BFBE8-E7BC-4EB7-A9DD-E114DA255B5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{351BFBE8-E7BC-4EB7-A9DD-E114DA255B5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{351BFBE8-E7BC-4EB7-A9DD-E114DA255B5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4C6B10A-6C62-4A31-A681-4DDB78320D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4C6B10A-6C62-4A31-A681-4DDB78320D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4C6B10A-6C62-4A31-A681-4DDB78320D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4C6B10A-6C62-4A31-A681-4DDB78320D9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds integration tests covering key AnalysesController endpoints including analysis creation, retrieval, error handling for invalid input, and message posting to analyses.

![{3308D7AB-0FA0-4723-9A7D-371726673336}](https://github.com/user-attachments/assets/de794a6e-71fc-44df-998f-8ed436694cec)